### PR TITLE
Исправление ошибки при добавлении профиля AutoMapper  в Startup.

### DIFF
--- a/src/TelegramBot/Startup.cs
+++ b/src/TelegramBot/Startup.cs
@@ -52,10 +52,7 @@ namespace DevQuiz.TelegramBot
             services.AddDevQuizRepositories<User, Question, Answer, Category, Tag, Guid>();
             services.AddDevQuizServices<User, UserDto, Guid>();
             
-            services.AddAutoMapper(new [] {
-                typeof(Startup),
-                typeof(UserMapperProfile<User, UserDto, Guid>)
-            });
+            services.AddAutoMapper(config => config.AddProfile<UserMapperProfile<User, UserDto, Guid>>());
 
             services.AddSingleton<IBotService, BotService>();
             services.AddScoped<IBotMessageService, BotMessageService>();


### PR DESCRIPTION
В таком виде сообщения приходят и обрабатываются. Не разобрался, отчего первый вариант не работал. Ответ нашёл на https://stackoverflow.com/questions/51927597/how-to-use-generic-profile-with-automapper-and-asp-net-core-dependency-injection.